### PR TITLE
feat: Discord attachment support with storage and cleanup

### DIFF
--- a/src/pepper/attachments.py
+++ b/src/pepper/attachments.py
@@ -1,0 +1,115 @@
+"""Attachment storage and cleanup for Pepper.
+
+Downloads files to ~/.pepper/attachments/YYYY-MM-DD/<id>_<filename>,
+with age-based and size-based cleanup.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import httpx
+
+from pepper.process import get_runtime_path
+
+log = logging.getLogger("pepper-attachments")
+
+MAX_AGE_DAYS = 30
+MAX_TOTAL_BYTES = 500 * 1024 * 1024  # 500MB
+
+
+def get_attachments_dir() -> Path:
+    """Return the root attachments directory."""
+    return get_runtime_path() / "attachments"
+
+
+def get_today_dir() -> Path:
+    """Return today's attachment subdirectory, creating it if needed."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    d = get_attachments_dir() / today
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+async def download_attachment(
+    url: str,
+    filename: str,
+    message_id: str,
+) -> Path | None:
+    """Download a file from a URL to the attachments directory.
+
+    Returns the local path on success, None on failure.
+    """
+    safe_name = f"{message_id}_{filename}".replace("/", "_").replace("\\", "_")
+    dest = get_today_dir() / safe_name
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, timeout=30.0, follow_redirects=True)
+            resp.raise_for_status()
+            dest.write_bytes(resp.content)
+            log.info(f"Downloaded attachment: {dest} ({len(resp.content)} bytes)")
+            return dest
+    except Exception as e:
+        log.error(f"Failed to download {url}: {e}")
+        return None
+
+
+def cleanup_attachments() -> dict[str, int]:
+    """Run cleanup: delete files older than MAX_AGE_DAYS, then enforce MAX_TOTAL_BYTES.
+
+    Returns stats about what was cleaned.
+    """
+    attachments_dir = get_attachments_dir()
+    if not attachments_dir.exists():
+        return {"deleted_age": 0, "deleted_size": 0}
+
+    deleted_age = 0
+    deleted_size = 0
+    cutoff = datetime.now() - timedelta(days=MAX_AGE_DAYS)
+
+    # Phase 1: delete by age (remove old date directories)
+    for date_dir in sorted(attachments_dir.iterdir()):
+        if not date_dir.is_dir():
+            continue
+        try:
+            dir_date = datetime.strptime(date_dir.name, "%Y-%m-%d")
+            if dir_date < cutoff:
+                count = sum(1 for _ in date_dir.rglob("*") if _.is_file())
+                shutil.rmtree(date_dir)
+                deleted_age += count
+                log.info(f"Cleaned up {date_dir.name} ({count} files, older than {MAX_AGE_DAYS} days)")
+        except ValueError:
+            continue  # skip non-date directories
+
+    # Phase 2: enforce size cap
+    total_size = _get_total_size(attachments_dir)
+    if total_size > MAX_TOTAL_BYTES:
+        # Delete oldest files until under cap
+        all_files = sorted(
+            (f for f in attachments_dir.rglob("*") if f.is_file()),
+            key=lambda f: f.stat().st_mtime,
+        )
+        for f in all_files:
+            if total_size <= MAX_TOTAL_BYTES:
+                break
+            size = f.stat().st_size
+            f.unlink()
+            total_size -= size
+            deleted_size += 1
+
+        # Clean up empty date directories
+        for date_dir in attachments_dir.iterdir():
+            if date_dir.is_dir() and not any(date_dir.iterdir()):
+                date_dir.rmdir()
+
+    return {"deleted_age": deleted_age, "deleted_size": deleted_size}
+
+
+def _get_total_size(directory: Path) -> int:
+    """Calculate total size of all files in a directory tree."""
+    return sum(f.stat().st_size for f in directory.rglob("*") if f.is_file())

--- a/src/pepper/integrations/discord/bot.py
+++ b/src/pepper/integrations/discord/bot.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 import discord
@@ -19,6 +20,7 @@ import httpx
 
 from .config import CHANNEL_URL
 from .embeds import build_embed
+from pepper.attachments import download_attachment
 
 log = logging.getLogger("pepper-discord")
 
@@ -67,18 +69,40 @@ async def on_message(message: discord.Message):
     chat_id = make_chat_id(message)
     is_dm = message.guild is None
 
+    # Download attachments and build content/metadata
+    content = message.content
+    attachment_infos = []
+    for att in message.attachments:
+        local_path = await download_attachment(
+            url=att.url,
+            filename=att.filename,
+            message_id=str(message.id),
+        )
+        if local_path:
+            attachment_infos.append({
+                "filename": att.filename,
+                "content_type": att.content_type or "unknown",
+                "path": str(local_path),
+                "size_bytes": local_path.stat().st_size,
+            })
+            content += f"\n[📎 {att.filename}]"
+
+    metadata = {
+        "guild_id": str(message.guild.id) if message.guild else "",
+        "channel_id": str(message.channel.id),
+        "message_id": str(message.id),
+        "is_dm": str(is_dm),
+        "author_id": str(message.author.id),
+    }
+    if attachment_infos:
+        metadata["attachments"] = json.dumps(attachment_infos)
+
     payload = {
         "source": "discord",
         "chat_id": chat_id,
         "sender": message.author.display_name,
-        "content": message.content,
-        "metadata": {
-            "guild_id": str(message.guild.id) if message.guild else "",
-            "channel_id": str(message.channel.id),
-            "message_id": str(message.id),
-            "is_dm": str(is_dm),
-            "author_id": str(message.author.id),
-        },
+        "content": content,
+        "metadata": metadata,
     }
 
     # Track the channel for typing indicator
@@ -193,19 +217,35 @@ async def handle_reply(data: dict[str, Any]):
     embed_data = metadata.get("embed")
     embed = build_embed(embed_data)
 
+    # Prepare outbound file attachments
+    files = []
+    outbound_attachments = metadata.get("attachments", [])
+    if isinstance(outbound_attachments, str):
+        try:
+            outbound_attachments = json.loads(outbound_attachments)
+        except json.JSONDecodeError:
+            outbound_attachments = []
+    for file_path in outbound_attachments:
+        p = Path(file_path)
+        if p.exists():
+            files.append(discord.File(str(p), filename=p.name))
+
     if text:
         # Discord has a 2000 char limit per message
         if len(text) <= 2000:
-            await channel.send(text, embed=embed)
+            await channel.send(text, embed=embed, files=files or None)
         else:
-            # Split into chunks
-            for i in range(0, len(text), 2000):
-                chunk = text[i:i + 2000]
-                # Only attach embed to the last chunk
-                chunk_embed = embed if i + 2000 >= len(text) else None
-                await channel.send(chunk, embed=chunk_embed)
-    elif embed:
-        await channel.send(embed=embed)
+            # Split into chunks, attach files to last chunk
+            chunks = [text[i:i + 2000] for i in range(0, len(text), 2000)]
+            for i, chunk in enumerate(chunks):
+                is_last = i == len(chunks) - 1
+                await channel.send(
+                    chunk,
+                    embed=embed if is_last else None,
+                    files=files if is_last else None,
+                )
+    elif embed or files:
+        await channel.send(text="" if files else None, embed=embed, files=files or None)
 
 
 # Common emoji name -> unicode mapping

--- a/src/pepper/integrations/discord/jobs.yaml
+++ b/src/pepper/integrations/discord/jobs.yaml
@@ -21,6 +21,14 @@ morning_briefing:
     Discord channel using send_discord_message with a rich embed.
   channel_hint: "#pepper-chat"
 
+attachment_cleanup:
+  trigger: cron
+  schedule:
+    hour: 4
+    minute: 0
+  type: function
+  function: pepper.attachments:cleanup_attachments
+
 nightly_reflection:
   trigger: cron
   schedule:

--- a/src/pepper/integrations/discord/scheduler.py
+++ b/src/pepper/integrations/discord/scheduler.py
@@ -58,6 +58,22 @@ def build_trigger(job_def: dict[str, Any]):
         raise ValueError(f"Unknown trigger type: {trigger_type}")
 
 
+async def execute_function_job(name: str, module_path: str):
+    """Execute a scheduled function job by importing and calling the function."""
+    try:
+        module_name, func_name = module_path.rsplit(":", 1)
+        import importlib
+        module = importlib.import_module(module_name)
+        func = getattr(module, func_name)
+        result = func()
+        # Handle both sync and async functions
+        if hasattr(result, "__await__"):
+            result = await result
+        log.info(f"Function job {name} completed: {result}")
+    except Exception as e:
+        log.error(f"Function job {name} failed: {e}")
+
+
 async def execute_job(name: str, prompt: str, channel_hint: str = ""):
     """Execute a scheduled job by POSTing to the channel server."""
     chat_id = f"scheduler-{name}-{int(time.time())}"
@@ -109,13 +125,24 @@ async def seed_default_jobs(scheduler: AsyncScheduler, yaml_path: Path):
             continue
 
         trigger = build_trigger(job_def)
-        prompt = job_def["prompt"]
-        channel_hint = job_def.get("channel_hint", "")
 
-        await scheduler.add_schedule(
-            execute_job,
-            trigger,
-            id=name,
-            args=[name, prompt, channel_hint],
-        )
+        if job_def.get("type") == "function":
+            # Direct Python function call (e.g., cleanup jobs)
+            func_path = job_def["function"]
+            await scheduler.add_schedule(
+                execute_function_job,
+                trigger,
+                id=name,
+                args=[name, func_path],
+            )
+        else:
+            # Default: prompt-based job via channel server
+            prompt = job_def["prompt"]
+            channel_hint = job_def.get("channel_hint", "")
+            await scheduler.add_schedule(
+                execute_job,
+                trigger,
+                id=name,
+                args=[name, prompt, channel_hint],
+            )
         log.info(f"Seeded job: {name}")

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,90 @@
+"""Tests for pepper.attachments — download, storage, and cleanup."""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from pepper.attachments import (
+    cleanup_attachments,
+    get_attachments_dir,
+    get_today_dir,
+    MAX_AGE_DAYS,
+    MAX_TOTAL_BYTES,
+)
+
+
+def test_get_today_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_runtime_path", lambda: tmp_path)
+    today = datetime.now().strftime("%Y-%m-%d")
+    result = get_today_dir()
+    assert result == tmp_path / "attachments" / today
+    assert result.is_dir()
+
+
+def test_cleanup_deletes_old_directories(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_attachments_dir", lambda: tmp_path)
+
+    # Create an old date directory (40 days ago)
+    old_date = (datetime.now() - timedelta(days=40)).strftime("%Y-%m-%d")
+    old_dir = tmp_path / old_date
+    old_dir.mkdir()
+    (old_dir / "old_file.txt").write_text("old")
+
+    # Create a recent date directory
+    recent_date = datetime.now().strftime("%Y-%m-%d")
+    recent_dir = tmp_path / recent_date
+    recent_dir.mkdir()
+    (recent_dir / "new_file.txt").write_text("new")
+
+    stats = cleanup_attachments()
+    assert stats["deleted_age"] == 1
+    assert not old_dir.exists()
+    assert recent_dir.exists()
+
+
+def test_cleanup_preserves_recent_directories(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_attachments_dir", lambda: tmp_path)
+
+    recent_date = datetime.now().strftime("%Y-%m-%d")
+    recent_dir = tmp_path / recent_date
+    recent_dir.mkdir()
+    (recent_dir / "file.txt").write_text("keep me")
+
+    stats = cleanup_attachments()
+    assert stats["deleted_age"] == 0
+    assert recent_dir.exists()
+
+
+def test_cleanup_enforces_size_cap(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_attachments_dir", lambda: tmp_path)
+    monkeypatch.setattr("pepper.attachments.MAX_TOTAL_BYTES", 100)  # 100 bytes cap
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    today_dir = tmp_path / today
+    today_dir.mkdir()
+
+    # Create files totaling > 100 bytes
+    (today_dir / "file1.txt").write_bytes(b"x" * 60)
+    (today_dir / "file2.txt").write_bytes(b"y" * 60)
+
+    stats = cleanup_attachments()
+    assert stats["deleted_size"] >= 1
+
+    # Total should now be under cap
+    total = sum(f.stat().st_size for f in tmp_path.rglob("*") if f.is_file())
+    assert total <= 100
+
+
+def test_cleanup_empty_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_attachments_dir", lambda: tmp_path)
+    stats = cleanup_attachments()
+    assert stats["deleted_age"] == 0
+    assert stats["deleted_size"] == 0
+
+
+def test_cleanup_nonexistent_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("pepper.attachments.get_attachments_dir", lambda: tmp_path / "nope")
+    stats = cleanup_attachments()
+    assert stats["deleted_age"] == 0
+    assert stats["deleted_size"] == 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -27,7 +27,10 @@ def test_jobs_yaml_required_fields():
     for name, job in jobs.items():
         assert "trigger" in job, f"Job {name} missing trigger"
         assert "schedule" in job, f"Job {name} missing schedule"
-        assert "prompt" in job, f"Job {name} missing prompt"
+        if job.get("type") == "function":
+            assert "function" in job, f"Function job {name} missing function"
+        else:
+            assert "prompt" in job, f"Job {name} missing prompt"
         assert job["trigger"] in ("interval", "cron", "once"), f"Job {name} has invalid trigger"
 
 
@@ -36,7 +39,7 @@ def test_load_seed_jobs():
     from pepper.integrations.discord.scheduler import load_seed_jobs
 
     jobs = load_seed_jobs(JOBS_YAML)
-    assert len(jobs) == 3
+    assert len(jobs) == 4
     assert "heartbeat" in jobs
     assert jobs["heartbeat"]["trigger"] == "interval"
     assert jobs["heartbeat"]["schedule"]["minutes"] == 30


### PR DESCRIPTION
## Summary

- Inbound: Discord bot downloads file attachments to `~/.pepper/attachments/YYYY-MM-DD/`, appends `[📎 filename]` to message content, includes full paths in metadata
- Outbound: reply tool `metadata.attachments` field sends files back to Discord
- Storage cleanup: daily cron at 4 AM, deletes files >30 days, enforces 500MB cap
- Scheduler now supports `type: function` jobs for direct Python calls (used by cleanup)

## Test plan

- [x] 101 tests passing (6 new attachment tests)
- [x] Cleanup handles age-based deletion, size cap enforcement, empty/missing dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)